### PR TITLE
remove setup.md from learners config section

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,7 +69,6 @@ episodes:
 
 # Information for Learners
 learners: 
-- setup.md
 #- setup-gpu.md ignored TODO how to have two setup files
 
 # Information for Instructors


### PR DESCRIPTION
After some investigation, I narrowed down the problem you were having with your site builds on GitHub: for reasons that are not clear to me, including `setup.md` in the list under `learners` in the `config.yaml` file causes the workflow to fail even though the site builds fine locally.

Merging this should fix your issue for now, and I will report this upstream so we can try to avoid anyone else running into the same problem.